### PR TITLE
Fix construction of query for elm oracle

### DIFF
--- a/pythonx/cm_sources/elm_oracle.py
+++ b/pythonx/cm_sources/elm_oracle.py
@@ -17,6 +17,7 @@ register_source(name='elm-oracle',
                 cm_refresh_patterns=[r'\.'],)
 
 import json
+import re
 import subprocess
 from os import path
 
@@ -36,7 +37,7 @@ class Source(Base):
         startcol = ctx['startcol']
         filepath = ctx['filepath']
 
-        query = typed.lstrip(" \t\'\"")
+        query = self._get_query(typed)
         args = ['elm-oracle', filepath, query]
 
         logger.debug("args: %s", args)
@@ -80,3 +81,9 @@ class Source(Base):
             return path.dirname(filepath)
 
         return ret
+
+    def _get_query(self, typed):
+        m = re.search(r'[^\s\'"]*$', typed)
+        if m:
+            return m.group()
+        return None


### PR DESCRIPTION
The current lstrip method isn't working, because the token, which is given to elm-oracle is far too big. This results in no suggestions returned by elm-oracle.  I changed the query construction to the same approach, deoplete is going (see [this](https://github.com/pbogut/deoplete-elm/blob/master/rplugin/python3/deoplete/sources/deoplete_elm.py#L34)). 